### PR TITLE
Resolve builtin multiarch Docker variables

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"runtime"
 
 	"github.com/keilerkonzept/dockerfile-json/pkg/dockerfile"
 	"github.com/yalp/jsonpath"
@@ -62,6 +63,28 @@ func init() {
 
 func buildArgEnvExpander() dockerfile.SingleWordExpander {
 	env := make(map[string]string, len(config.BuildArgs.Values))
+
+	// Detect user's os and arch
+	buildOS := runtime.GOOS
+	buildArch := runtime.GOARCH
+	buildPlatform := buildOS + "/" + buildArch
+
+	// Define built-in Docker ARG variables
+	// See https://docs.docker.com/build/building/multi-platform/
+	builtinArgs := map[string]string{
+		"TARGETPLATFORM": buildPlatform,
+		"TARGETARCH":     buildArch,
+		"TARGETOS":       buildOS,
+		"BUILDPLATFORM":  buildPlatform,
+		"BUILDARCH":      buildArch,
+		"BUILDOS":        buildOS,
+	}
+
+	// Add the builtin args to the environment
+	for key, value := range builtinArgs {
+		env[key] = value
+	}
+
 	for key, value := range config.BuildArgs.Values {
 		if value != nil {
 			env[key] = *value


### PR DESCRIPTION
Docker exposes various variables related to multi-platform building in its builds.[1]

dockerfile-json currently does not account for these variables and does not resolve them properly.

For example:
`FROM BASE-${TARGETARCH}` resolves to `BASE-` but should resolve to the actual architecture that is used like `BASE-amd64`

Detect the user's arch and OS and expose it via the variables. Let users overwrite it via build args if they need to.

[1]: https://docs.docker.com/build/building/multi-platform/