### PR TITLE
Support complex ARG variable expansion in commands

### DIFF
--- a/pkg/dockerfile/expand.go
+++ b/pkg/dockerfile/expand.go
@@ -16,20 +16,62 @@ func (d *Dockerfile) Expand(env SingleWordExpander) {
 
 func (d *Dockerfile) expand(env instructions.SingleWordExpander) {
 	metaArgsEnvExpander := d.metaArgsEnvExpander(env)
+
+	// Create an os.Expand-compatible function from the SingleWordExpander
+	expandFunc := func(key string) string {
+		value, err := metaArgsEnvExpander(key)
+		if err != nil {
+			return ""
+		}
+		return value
+	}
+
 	for i, stage := range d.Stages {
-		d.Stages[i].BaseName = os.Expand(stage.BaseName, func(key string) string {
-			value, err := metaArgsEnvExpander(key)
-			if err != nil {
-				return ""
-			}
-			return value
-		})
+		d.Stages[i].BaseName = os.Expand(stage.BaseName, expandFunc)
+
 		for i := range stage.Commands {
-			cmdExpander, ok := stage.Commands[i].Command.(instructions.SupportsSingleWordExpansion)
-			if ok {
-				cmdExpander.Expand(metaArgsEnvExpander)
+			// Expand commands using os.Expand instead of delegating to buildkit
+			// This allows complex expressions like "$VERSION+git-$REVISION" to work
+			d.expandCommand(stage.Commands[i], expandFunc)
+		}
+	}
+}
+
+// expandCommand expands variables in command values using os.Expand
+func (d *Dockerfile) expandCommand(cmd *Command, expandFunc func(string) string) {
+	switch c := cmd.Command.(type) {
+	case *instructions.LabelCommand:
+		// Expand LABEL key-value pairs
+		for i := range c.Labels {
+			c.Labels[i].Key = os.Expand(c.Labels[i].Key, expandFunc)
+			c.Labels[i].Value = os.Expand(c.Labels[i].Value, expandFunc)
+		}
+	case *instructions.EnvCommand:
+		// Expand ENV key-value pairs
+		for i := range c.Env {
+			c.Env[i].Key = os.Expand(c.Env[i].Key, expandFunc)
+			c.Env[i].Value = os.Expand(c.Env[i].Value, expandFunc)
+		}
+	case *instructions.ArgCommand:
+		// Expand ARG values
+		for i := range c.Args {
+			if c.Args[i].Value != nil {
+				expanded := os.Expand(*c.Args[i].Value, expandFunc)
+				c.Args[i].Value = &expanded
 			}
 		}
+	case *instructions.WorkdirCommand:
+		// Expand WORKDIR path
+		c.Path = os.Expand(c.Path, expandFunc)
+	case *instructions.UserCommand:
+		// Expand USER value
+		c.User = os.Expand(c.User, expandFunc)
+	case instructions.SupportsSingleWordExpansion:
+		// For other commands that support expansion, use buildkit's method
+		// This is a fallback for commands we haven't explicitly handled
+		c.Expand(func(word string) (string, error) {
+			return os.Expand(word, expandFunc), nil
+		})
 	}
 }
 

--- a/pkg/dockerfile/expand_test.go
+++ b/pkg/dockerfile/expand_test.go
@@ -1,0 +1,231 @@
+package dockerfile
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/moby/buildkit/frontend/dockerfile/instructions"
+)
+
+func TestLabelExpansion(t *testing.T) {
+	tests := []struct {
+		name           string
+		dockerfile     string
+		buildArgs      map[string]string
+		expectedLabels map[string]string
+	}{
+		{
+			name: "simple variable expansion",
+			dockerfile: `ARG VERSION=1.0.0
+FROM alpine:3.10
+LABEL version="$VERSION"`,
+			buildArgs: map[string]string{},
+			expectedLabels: map[string]string{
+				"version": "1.0.0",
+			},
+		},
+		{
+			name: "complex expression with multiple variables",
+			dockerfile: `ARG VERSION=1.0.0
+ARG REVISION=abc123
+FROM alpine:3.10
+LABEL version="$VERSION+git-$REVISION"`,
+			buildArgs: map[string]string{},
+			expectedLabels: map[string]string{
+				"version": "1.0.0+git-abc123",
+			},
+		},
+		{
+			name: "braced variable expansion",
+			dockerfile: `ARG VERSION=1.0.0
+ARG REVISION=abc123
+FROM alpine:3.10
+LABEL version="${VERSION}-${REVISION}"`,
+			buildArgs: map[string]string{},
+			expectedLabels: map[string]string{
+				"version": "1.0.0-abc123",
+			},
+		},
+		{
+			name: "mixed variables and literals",
+			dockerfile: `ARG VERSION=2.5.0
+FROM alpine:3.10
+LABEL description="App version $VERSION is ready"`,
+			buildArgs: map[string]string{},
+			expectedLabels: map[string]string{
+				"description": "App version 2.5.0 is ready",
+			},
+		},
+		{
+			name: "override with build-arg",
+			dockerfile: `ARG VERSION=1.0.0
+ARG REVISION=default
+FROM alpine:3.10
+LABEL version="$VERSION+git-$REVISION"`,
+			buildArgs: map[string]string{
+				"REVISION": "xyz789",
+			},
+			expectedLabels: map[string]string{
+				"version": "1.0.0+git-xyz789",
+			},
+		},
+		{
+			name: "multiple labels with expansion",
+			dockerfile: `ARG VERSION=1.0.0
+ARG REVISION=abc123
+FROM alpine:3.10
+LABEL version="$VERSION"
+LABEL revision="$REVISION"
+LABEL combined="$VERSION+git-$REVISION"`,
+			buildArgs: map[string]string{},
+			expectedLabels: map[string]string{
+				"version":  "1.0.0",
+				"revision": "abc123",
+				"combined": "1.0.0+git-abc123",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Parse the dockerfile
+			df, err := ParseReader(strings.NewReader(tt.dockerfile))
+			if err != nil {
+				t.Fatalf("Failed to parse dockerfile: %v", err)
+			}
+
+			// Create build arg expander
+			env := func(key string) (string, error) {
+				if val, ok := tt.buildArgs[key]; ok {
+					return val, nil
+				}
+				// Return error if not found - this allows ARG defaults to be used
+				return "", fmt.Errorf("not defined: $%s", key)
+			}
+
+			// Expand
+			df.Expand(env)
+
+			// Find LABEL commands and verify
+			foundLabels := make(map[string]string)
+			for _, stage := range df.Stages {
+				for _, cmd := range stage.Commands {
+					if cmd.Name == "LABEL" {
+						labelCmd, ok := cmd.Command.(*instructions.LabelCommand)
+						if !ok {
+							t.Fatalf("Expected *instructions.LabelCommand, got %T", cmd.Command)
+						}
+						for _, label := range labelCmd.Labels {
+							// Remove quotes if present
+							value := strings.Trim(label.Value, "\"")
+							foundLabels[label.Key] = value
+						}
+					}
+				}
+			}
+
+			// Verify expected labels
+			for key, expectedValue := range tt.expectedLabels {
+				actualValue, found := foundLabels[key]
+				if !found {
+					t.Errorf("Label %q not found in output", key)
+					continue
+				}
+				if actualValue != expectedValue {
+					t.Errorf("Label %q: expected %q, got %q", key, expectedValue, actualValue)
+				}
+			}
+
+			// Verify no extra labels
+			for key := range foundLabels {
+				if _, expected := tt.expectedLabels[key]; !expected {
+					t.Errorf("Unexpected label %q with value %q", key, foundLabels[key])
+				}
+			}
+		})
+	}
+}
+
+func TestEnvExpansion(t *testing.T) {
+	tests := []struct {
+		name        string
+		dockerfile  string
+		buildArgs   map[string]string
+		expectedEnv map[string]string
+	}{
+		{
+			name: "ENV with variable expansion",
+			dockerfile: `ARG VERSION=1.0.0
+FROM alpine:3.10
+ENV APP_VERSION=$VERSION`,
+			buildArgs: map[string]string{},
+			expectedEnv: map[string]string{
+				"APP_VERSION": "1.0.0",
+			},
+		},
+		{
+			name: "ENV with complex expression",
+			dockerfile: `ARG VERSION=1.0.0
+ARG REVISION=abc123
+FROM alpine:3.10
+ENV FULL_VERSION="$VERSION+git-$REVISION"`,
+			buildArgs: map[string]string{},
+			expectedEnv: map[string]string{
+				"FULL_VERSION": "1.0.0+git-abc123",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Parse the dockerfile
+			df, err := ParseReader(strings.NewReader(tt.dockerfile))
+			if err != nil {
+				t.Fatalf("Failed to parse dockerfile: %v", err)
+			}
+
+			// Create build arg expander
+			env := func(key string) (string, error) {
+				if val, ok := tt.buildArgs[key]; ok {
+					return val, nil
+				}
+				// Return error if not found - this allows ARG defaults to be used
+				return "", fmt.Errorf("not defined: $%s", key)
+			}
+
+			// Expand
+			df.Expand(env)
+
+			// Find ENV commands and verify
+			foundEnv := make(map[string]string)
+			for _, stage := range df.Stages {
+				for _, cmd := range stage.Commands {
+					if cmd.Name == "ENV" {
+						envCmd, ok := cmd.Command.(*instructions.EnvCommand)
+						if !ok {
+							t.Fatalf("Expected *instructions.EnvCommand, got %T", cmd.Command)
+						}
+						for _, kv := range envCmd.Env {
+							// Remove quotes if present
+							value := strings.Trim(kv.Value, "\"")
+							foundEnv[kv.Key] = value
+						}
+					}
+				}
+			}
+
+			// Verify expected env vars
+			for key, expectedValue := range tt.expectedEnv {
+				actualValue, found := foundEnv[key]
+				if !found {
+					t.Errorf("ENV %q not found in output", key)
+					continue
+				}
+				if actualValue != expectedValue {
+					t.Errorf("ENV %q: expected %q, got %q", key, expectedValue, actualValue)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes ARG expansion in LABEL, ENV, and other Dockerfile commands to support complex expressions like `$VERSION+git-$REVISION`. This addresses https://issues.redhat.com/browse/STONEBLD-3924.

## Problem

Previously, LABEL and ENV commands with complex variable expressions were not properly expanded:

```dockerfile
ARG VERSION=1.0.0
ARG REVISION=abc123
LABEL version="$VERSION+git-$REVISION"
```

**Before:** `"$VERSION+git-$REVISION"` (unexpanded)
**After:** `"1.0.0+git-abc123"` (properly expanded) ✅

The root cause was that buildkit's `SingleWordExpander` interface is designed for individual variable names, not full strings with embedded variables and literals.

## Solution

This PR modifies the expansion logic in `pkg/dockerfile/expand.go` to use `os.Expand` for command values (similar to how `BaseName` is already expanded), allowing proper handling of:
- Simple variables: `$VERSION`
- Braced variables: `${VERSION}`
- Complex expressions: `$VERSION+git-$REVISION`
- Multiple variables: `"version $VERSION revision $REVISION"`

Commands explicitly handled: LABEL, ENV, ARG, WORKDIR, USER (with fallback for others)

## Alternative Considered: shell.Lex

We considered using buildkit's `shell.Lex` for expansion instead of `os.Expand`:

**Pros:**
- More robust shell-like expansion
- Proper quote handling (respects single vs double quotes)
- Matches Docker's actual build behavior more closely

**Cons:**
- **Quote stripping:** Changes output format from `"Value": "\"1.0.0\""` to `"Value": "1.0.0"` (breaking change)
- More complex integration (requires implementing `EnvGetter` interface)
- Slightly higher performance overhead
- Breaks backward compatibility

**Decision:** Used `os.Expand` for consistency with existing `BaseName` expansion and to avoid breaking changes.

## Testing

Added comprehensive test suite (`pkg/dockerfile/expand_test.go`) with 8 test cases covering:
- Simple and braced variable expansion
- Complex multi-variable expressions
- Build arg overrides
- Both LABEL and ENV commands

All tests passing ✅

## Related

- Fixes: https://issues.redhat.com/browse/STONEBLD-3924
- Related PR: https://github.com/konflux-ci/build-definitions/pull/2922
- Addresses feedback from @chmeliik to fix in dockerfile-json rather than build-definitions

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>