### PR TITLE
Add support for --env

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,12 @@ dockerfile-json [PATHS...]
 Usage of dockerfile-json:
   -build-arg value
     	a key/value pair KEY[=VALUE]
+  -env value
+    	a key/value pair KEY[=VALUE]
   -expand-build-args
-    	expand build args (default true)
+    	DEPRECATED: use --expand-vars (expands ARG and ENV variables) (default true)
+  -expand-vars
+    	expand build ARGs and ENV variables (default true)
   -jsonpath string
     	select parts of the output using JSONPath (https://goessner.net/articles/JsonPath)
   -jsonpath-raw

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ var config struct {
 	JSONPath       jsonpath.FilterFunc
 	JSONPathRaw    bool
 	BuildArgs      AssignmentsMap
+	EnvVars        AssignmentsMap
 	NonzeroExit    bool
 }
 
@@ -35,10 +36,13 @@ func init() {
 
 	config.Expand = true
 	flag.BoolVar(&config.Quiet, "quiet", config.Quiet, "suppress log output (stderr)")
-	flag.BoolVar(&config.Expand, "expand-build-args", config.Expand, "expand build args")
+	flag.BoolVar(&config.Expand, "expand-build-args", config.Expand, "DEPRECATED: use --expand-vars (expands ARG and ENV variables)")
+	flag.BoolVar(&config.Expand, "expand-vars", config.Expand, "expand build ARGs and ENV variables")
 	flag.StringVar(&config.JSONPathString, "jsonpath", config.JSONPathString, "select parts of the output using JSONPath (https://goessner.net/articles/JsonPath)")
 	flag.BoolVar(&config.JSONPathRaw, "jsonpath-raw", config.JSONPathRaw, "when using JSONPath, output raw strings, not JSON values")
 	flag.Var(&config.BuildArgs, "build-arg", config.BuildArgs.Help())
+	flag.Var(&config.EnvVars, "env", config.EnvVars.Help())
+
 }
 
 func parseFlags() {
@@ -64,8 +68,8 @@ func parseFlags() {
 	}
 }
 
-func buildArgEnvExpander() dockerfile.SingleWordExpander {
-	env := make(map[string]string, len(config.BuildArgs.Values))
+func buildArgExpander() dockerfile.SingleWordExpander {
+	args := make(map[string]string, len(config.BuildArgs.Values))
 
 	// Detect user's os and arch
 	buildOS := runtime.GOOS
@@ -85,10 +89,31 @@ func buildArgEnvExpander() dockerfile.SingleWordExpander {
 
 	// Add the builtin args to the environment
 	for key, value := range builtinArgs {
-		env[key] = value
+		args[key] = value
 	}
 
 	for key, value := range config.BuildArgs.Values {
+		if value != nil {
+			args[key] = *value
+			continue
+		}
+		if value, ok := os.LookupEnv(key); ok {
+			args[key] = value
+		}
+	}
+
+	return func(word string) (string, error) {
+		if value, ok := args[word]; ok {
+			return value, nil
+		}
+		return "", fmt.Errorf("not defined: $%s", word)
+	}
+}
+
+func envExpander() dockerfile.SingleWordExpander {
+	env := make(map[string]string, len(config.EnvVars.Values))
+
+	for key, value := range config.EnvVars.Values {
 		if value != nil {
 			env[key] = *value
 			continue
@@ -97,6 +122,7 @@ func buildArgEnvExpander() dockerfile.SingleWordExpander {
 			env[key] = value
 		}
 	}
+
 	return func(word string) (string, error) {
 		if value, ok := env[word]; ok {
 			return value, nil
@@ -119,9 +145,10 @@ func main() {
 		dockerfiles = append(dockerfiles, dockerfile)
 	}
 	if config.Expand {
-		env := buildArgEnvExpander()
+		argExp := buildArgExpander()
+		envExp := envExpander()
 		for _, dockerfile := range dockerfiles {
-			dockerfile.Expand(env)
+			dockerfile.Expand(argExp, envExp)
 		}
 	}
 	switch {

--- a/pkg/dockerfile/expand.go
+++ b/pkg/dockerfile/expand.go
@@ -8,13 +8,14 @@ import (
 
 type SingleWordExpander instructions.SingleWordExpander
 
-func (d *Dockerfile) Expand(env SingleWordExpander) {
-	d.expand(instructions.SingleWordExpander(env))
+func (d *Dockerfile) Expand(argExp, envExp SingleWordExpander) {
+	d.expand(instructions.SingleWordExpander(argExp), instructions.SingleWordExpander(envExp))
 	d.analyzeStages()
 }
 
-func (d *Dockerfile) expand(env instructions.SingleWordExpander) {
-	metaArgs := d.buildMetaArgs(env)
+func (d *Dockerfile) expand(argExp, envExp instructions.SingleWordExpander) {
+	// Should be created only from the build args, no env variables here
+	metaArgs := d.buildMetaArgs(argExp)
 	for i, stage := range d.Stages {
 		d.Stages[i].BaseName = os.Expand(d.Stages[i].BaseName, func(varname string) string {
 			return metaArgs[varname]
@@ -25,9 +26,13 @@ func (d *Dockerfile) expand(env instructions.SingleWordExpander) {
 
 		expandLocalVars := func(s string) (string, error) {
 			expanded := os.Expand(s, func(varname string) string {
-				// ENVs take precedence over ARGs
+				// Containerfile defined ENVs take precedence over ENV variables defined through CLI (--env) and ARGs
 				if envVal, ok := localEnvs[varname]; ok {
 					return envVal
+				}
+				// Env variables provided from CLI
+				if cliEnvVal, err := envExp(varname); err == nil {
+					return cliEnvVal
 				}
 				if argVal, ok := localArgs[varname]; ok {
 					return argVal
@@ -52,7 +57,7 @@ func (d *Dockerfile) expand(env instructions.SingleWordExpander) {
 			case *instructions.ArgCommand:
 				for i := range command.Args {
 					arg := &command.Args[i]
-					if val, err := env(arg.Key); err == nil {
+					if val, err := argExp(arg.Key); err == nil {
 						// Override with externally supplied arg value
 						arg.Value = &val
 					} else if arg.Value == nil {
@@ -70,14 +75,14 @@ func (d *Dockerfile) expand(env instructions.SingleWordExpander) {
 	}
 }
 
-func (d *Dockerfile) buildMetaArgs(env instructions.SingleWordExpander) map[string]string {
+func (d *Dockerfile) buildMetaArgs(argExp instructions.SingleWordExpander) map[string]string {
 	metaArgs := make(map[string]string, len(d.MetaArgs))
 	for _, arg := range d.MetaArgs {
 		if defaultValue := arg.DefaultValue; defaultValue != nil {
 			metaArgs[arg.Key] = *defaultValue
 		}
 
-		if value, err := env(arg.Key); err == nil {
+		if value, err := argExp(arg.Key); err == nil {
 			arg.ProvidedValue = &value
 			metaArgs[arg.Key] = value
 			arg.Value = &value

--- a/testdata/basic-env-var-cli-expansion/Containerfile
+++ b/testdata/basic-env-var-cli-expansion/Containerfile
@@ -1,0 +1,4 @@
+FROM scratch
+
+# Has the value provided by the --env CLI parameter
+LABEL version=${VERSION}

--- a/testdata/basic-env-var-cli-expansion/args.txt
+++ b/testdata/basic-env-var-cli-expansion/args.txt
@@ -1,0 +1,2 @@
+--env
+VERSION=2.0.0

--- a/testdata/basic-env-var-cli-expansion/expand-vars-set-to-false/args.txt
+++ b/testdata/basic-env-var-cli-expansion/expand-vars-set-to-false/args.txt
@@ -1,0 +1,4 @@
+--env
+VERSION=2.0.0
+
+--expand-vars=false

--- a/testdata/basic-env-var-cli-expansion/expand-vars-set-to-false/expected.json
+++ b/testdata/basic-env-var-cli-expansion/expand-vars-set-to-false/expected.json
@@ -1,0 +1,43 @@
+{
+  "MetaArgs": null,
+  "Stages": [
+    {
+      "Name": "",
+      "OrigCmd": "FROM",
+      "BaseName": "scratch",
+      "Platform": "",
+      "Comment": "",
+      "SourceCode": "FROM scratch",
+      "Location": [
+        {
+          "Start": {
+            "Line": 1,
+            "Character": 0
+          },
+          "End": {
+            "Line": 1,
+            "Character": 0
+          }
+        }
+      ],
+      "From": {
+        "Scratch": true
+      },
+      "Commands": [
+        {
+          "Labels": [
+            {
+              "Key": "version",
+              "NoDelim": false,
+              "Value": "${VERSION}"
+            }
+          ],
+          "Mounts": null,
+          "Name": "LABEL",
+          "NetworkMode": "",
+          "Security": ""
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/basic-env-var-cli-expansion/expected.json
+++ b/testdata/basic-env-var-cli-expansion/expected.json
@@ -1,0 +1,43 @@
+{
+  "MetaArgs": null,
+  "Stages": [
+    {
+      "Name": "",
+      "OrigCmd": "FROM",
+      "BaseName": "scratch",
+      "Platform": "",
+      "Comment": "",
+      "SourceCode": "FROM scratch",
+      "Location": [
+        {
+          "Start": {
+            "Line": 1,
+            "Character": 0
+          },
+          "End": {
+            "Line": 1,
+            "Character": 0
+          }
+        }
+      ],
+      "From": {
+        "Scratch": true
+      },
+      "Commands": [
+        {
+          "Labels": [
+            {
+              "Key": "version",
+              "NoDelim": false,
+              "Value": "2.0.0"
+            }
+          ],
+          "Mounts": null,
+          "Name": "LABEL",
+          "NetworkMode": "",
+          "Security": ""
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/basic-env-var-cli-no-effect/Containerfile
+++ b/testdata/basic-env-var-cli-no-effect/Containerfile
@@ -1,0 +1,6 @@
+FROM scratch
+
+ENV VERSION=1.0.0
+
+# Has value 1.0.0, because the local ENV VERSION value takes precedence over the CLI value
+LABEL version=${VERSION}

--- a/testdata/basic-env-var-cli-no-effect/args.txt
+++ b/testdata/basic-env-var-cli-no-effect/args.txt
@@ -1,0 +1,2 @@
+--env
+VERSION=2.0.0

--- a/testdata/basic-env-var-cli-no-effect/expand-vars-set-to-false/args.txt
+++ b/testdata/basic-env-var-cli-no-effect/expand-vars-set-to-false/args.txt
@@ -1,0 +1,4 @@
+--env
+VERSION=2.0.0
+
+--expand-vars=false

--- a/testdata/basic-env-var-cli-no-effect/expand-vars-set-to-false/expected.json
+++ b/testdata/basic-env-var-cli-no-effect/expand-vars-set-to-false/expected.json
@@ -1,0 +1,56 @@
+{
+  "MetaArgs": null,
+  "Stages": [
+    {
+      "Name": "",
+      "OrigCmd": "FROM",
+      "BaseName": "scratch",
+      "Platform": "",
+      "Comment": "",
+      "SourceCode": "FROM scratch",
+      "Location": [
+        {
+          "Start": {
+            "Line": 1,
+            "Character": 0
+          },
+          "End": {
+            "Line": 1,
+            "Character": 0
+          }
+        }
+      ],
+      "From": {
+        "Scratch": true
+      },
+      "Commands": [
+        {
+          "Env": [
+            {
+              "Key": "VERSION",
+              "NoDelim": false,
+              "Value": "1.0.0"
+            }
+          ],
+          "Mounts": null,
+          "Name": "ENV",
+          "NetworkMode": "",
+          "Security": ""
+        },
+        {
+          "Labels": [
+            {
+              "Key": "version",
+              "NoDelim": false,
+              "Value": "${VERSION}"
+            }
+          ],
+          "Mounts": null,
+          "Name": "LABEL",
+          "NetworkMode": "",
+          "Security": ""
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/basic-env-var-cli-no-effect/expected.json
+++ b/testdata/basic-env-var-cli-no-effect/expected.json
@@ -1,0 +1,56 @@
+{
+  "MetaArgs": null,
+  "Stages": [
+    {
+      "Name": "",
+      "OrigCmd": "FROM",
+      "BaseName": "scratch",
+      "Platform": "",
+      "Comment": "",
+      "SourceCode": "FROM scratch",
+      "Location": [
+        {
+          "Start": {
+            "Line": 1,
+            "Character": 0
+          },
+          "End": {
+            "Line": 1,
+            "Character": 0
+          }
+        }
+      ],
+      "From": {
+        "Scratch": true
+      },
+      "Commands": [
+        {
+          "Env": [
+            {
+              "Key": "VERSION",
+              "NoDelim": false,
+              "Value": "1.0.0"
+            }
+          ],
+          "Mounts": null,
+          "Name": "ENV",
+          "NetworkMode": "",
+          "Security": ""
+        },
+        {
+          "Labels": [
+            {
+              "Key": "version",
+              "NoDelim": false,
+              "Value": "1.0.0"
+            }
+          ],
+          "Mounts": null,
+          "Name": "LABEL",
+          "NetworkMode": "",
+          "Security": ""
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/meta-arg-precedence-over-env/Containerfile
+++ b/testdata/meta-arg-precedence-over-env/Containerfile
@@ -1,0 +1,7 @@
+ARG ALPINE_TAG=3.10
+
+FROM alpine:${ALPINE_TAG} AS build
+# The env should not override the build arg value for the MetaArgs
+# that is used for expansion of stage names/images. 
+# The value of the env variable ALPINE_TAG should also not be overriden even if --env CLI value provided
+ENV ALPINE_TAG=5.10

--- a/testdata/meta-arg-precedence-over-env/env-var-and-build-arg-cli-override/args.txt
+++ b/testdata/meta-arg-precedence-over-env/env-var-and-build-arg-cli-override/args.txt
@@ -1,0 +1,5 @@
+--env
+ALPINE_TAG=10.10
+
+--build-arg
+ALPINE_TAG=1.10

--- a/testdata/meta-arg-precedence-over-env/env-var-and-build-arg-cli-override/expected.json
+++ b/testdata/meta-arg-precedence-over-env/env-var-and-build-arg-cli-override/expected.json
@@ -1,0 +1,51 @@
+{
+  "MetaArgs": [
+    {
+      "Key": "ALPINE_TAG",
+      "DefaultValue": "3.10",
+      "ProvidedValue": "1.10",
+      "Value": "1.10"
+    }
+  ],
+  "Stages": [
+    {
+      "Name": "build",
+      "OrigCmd": "FROM",
+      "BaseName": "alpine:1.10",
+      "Platform": "",
+      "Comment": "",
+      "SourceCode": "FROM alpine:${ALPINE_TAG} AS build",
+      "Location": [
+        {
+          "Start": {
+            "Line": 3,
+            "Character": 0
+          },
+          "End": {
+            "Line": 3,
+            "Character": 0
+          }
+        }
+      ],
+      "As": "build",
+      "From": {
+        "Image": "alpine:1.10"
+      },
+      "Commands": [
+        {
+          "Env": [
+            {
+              "Key": "ALPINE_TAG",
+              "NoDelim": false,
+              "Value": "5.10"
+            }
+          ],
+          "Mounts": null,
+          "Name": "ENV",
+          "NetworkMode": "",
+          "Security": ""
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/meta-arg-precedence-over-env/env-var-cli-override/args.txt
+++ b/testdata/meta-arg-precedence-over-env/env-var-cli-override/args.txt
@@ -1,0 +1,2 @@
+--env
+ALPINE_TAG=10.10

--- a/testdata/meta-arg-precedence-over-env/env-var-cli-override/expected.json
+++ b/testdata/meta-arg-precedence-over-env/env-var-cli-override/expected.json
@@ -1,0 +1,51 @@
+{
+  "MetaArgs": [
+    {
+      "Key": "ALPINE_TAG",
+      "DefaultValue": "3.10",
+      "ProvidedValue": null,
+      "Value": "3.10"
+    }
+  ],
+  "Stages": [
+    {
+      "Name": "build",
+      "OrigCmd": "FROM",
+      "BaseName": "alpine:3.10",
+      "Platform": "",
+      "Comment": "",
+      "SourceCode": "FROM alpine:${ALPINE_TAG} AS build",
+      "Location": [
+        {
+          "Start": {
+            "Line": 3,
+            "Character": 0
+          },
+          "End": {
+            "Line": 3,
+            "Character": 0
+          }
+        }
+      ],
+      "As": "build",
+      "From": {
+        "Image": "alpine:3.10"
+      },
+      "Commands": [
+        {
+          "Env": [
+            {
+              "Key": "ALPINE_TAG",
+              "NoDelim": false,
+              "Value": "5.10"
+            }
+          ],
+          "Mounts": null,
+          "Name": "ENV",
+          "NetworkMode": "",
+          "Security": ""
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/meta-arg-precedence-over-env/expected.json
+++ b/testdata/meta-arg-precedence-over-env/expected.json
@@ -1,0 +1,51 @@
+{
+  "MetaArgs": [
+    {
+      "Key": "ALPINE_TAG",
+      "DefaultValue": "3.10",
+      "ProvidedValue": null,
+      "Value": "3.10"
+    }
+  ],
+  "Stages": [
+    {
+      "Name": "build",
+      "OrigCmd": "FROM",
+      "BaseName": "alpine:3.10",
+      "Platform": "",
+      "Comment": "",
+      "SourceCode": "FROM alpine:${ALPINE_TAG} AS build",
+      "Location": [
+        {
+          "Start": {
+            "Line": 3,
+            "Character": 0
+          },
+          "End": {
+            "Line": 3,
+            "Character": 0
+          }
+        }
+      ],
+      "As": "build",
+      "From": {
+        "Image": "alpine:3.10"
+      },
+      "Commands": [
+        {
+          "Env": [
+            {
+              "Key": "ALPINE_TAG",
+              "NoDelim": false,
+              "Value": "5.10"
+            }
+          ],
+          "Mounts": null,
+          "Name": "ENV",
+          "NetworkMode": "",
+          "Security": ""
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Allows user to specify env vars as CLI parameter, which can be used for
variable subsitution/replacement values in the Containerfile.

E.g. if you have Containerfile:
FROM scratch
LABEL version=${VERSION}

And you do
./dockerfile-json --env VERSION=2.0.0 testdata/basic-env-var-cli-expansion/Containerfile

Then the resulting label VERSION will be parsed with value 2.0.0.

STONEBLD-3890