### PR TITLE
Refactor env handling

### DIFF
--- a/main.go
+++ b/main.go
@@ -110,27 +110,6 @@ func buildArgExpander() dockerfile.SingleWordExpander {
 	}
 }
 
-func envExpander() dockerfile.SingleWordExpander {
-	env := make(map[string]string, len(config.EnvVars.Values))
-
-	for key, value := range config.EnvVars.Values {
-		if value != nil {
-			env[key] = *value
-			continue
-		}
-		if value, ok := os.LookupEnv(key); ok {
-			env[key] = value
-		}
-	}
-
-	return func(word string) (string, error) {
-		if value, ok := env[word]; ok {
-			return value, nil
-		}
-		return "", fmt.Errorf("not defined: $%s", word)
-	}
-}
-
 func main() {
 	parseFlags()
 
@@ -162,10 +141,8 @@ func main() {
 
 	if config.Expand {
 		argExp := buildArgExpander()
-		envExp := envExpander()
-
 		for _, dockerfile := range dockerfiles {
-			dockerfile.Expand(argExp, envExp)
+			dockerfile.Expand(argExp)
 		}
 	}
 	switch {

--- a/pkg/dockerfile/expand.go
+++ b/pkg/dockerfile/expand.go
@@ -9,6 +9,10 @@ import (
 
 type SingleWordExpander instructions.SingleWordExpander
 
+// Expand the ENV and ARG variable references in instructions.
+//
+// When injecting additional environment variables, InjectEnv()
+// must be called first in order for Expand() to work properly.
 func (d *Dockerfile) Expand(argExp SingleWordExpander) {
 	d.expand(instructions.SingleWordExpander(argExp))
 	d.analyzeStages()

--- a/pkg/dockerfile/expand.go
+++ b/pkg/dockerfile/expand.go
@@ -9,13 +9,12 @@ import (
 
 type SingleWordExpander instructions.SingleWordExpander
 
-func (d *Dockerfile) Expand(argExp, envExp SingleWordExpander) {
-	d.expand(instructions.SingleWordExpander(argExp), instructions.SingleWordExpander(envExp))
+func (d *Dockerfile) Expand(argExp SingleWordExpander) {
+	d.expand(instructions.SingleWordExpander(argExp))
 	d.analyzeStages()
 }
 
-func (d *Dockerfile) expand(argExp, envExp instructions.SingleWordExpander) {
-	// Should be created only from the build args, no env variables here
+func (d *Dockerfile) expand(argExp instructions.SingleWordExpander) {
 	metaArgs := d.buildMetaArgs(argExp)
 	for i, stage := range d.Stages {
 		d.Stages[i].BaseName = os.Expand(d.Stages[i].BaseName, func(varname string) string {
@@ -27,13 +26,9 @@ func (d *Dockerfile) expand(argExp, envExp instructions.SingleWordExpander) {
 
 		expandLocalVars := func(s string) (string, error) {
 			expanded := os.Expand(s, func(varname string) string {
-				// Containerfile defined ENVs take precedence over ENV variables defined through CLI (--env) and ARGs
+				// ENVs take precedence over ARGs
 				if envVal, ok := localEnvs[varname]; ok {
 					return envVal
-				}
-				// Env variables provided from CLI
-				if cliEnvVal, err := envExp(varname); err == nil {
-					return cliEnvVal
 				}
 				if argVal, ok := localArgs[varname]; ok {
 					return argVal


### PR DESCRIPTION
We're injecting ENV instruction into each stage via the InjectEnv()
method, which is all we need for variable expansion to work properly.
We don't need any special handling in the Expand() method.

Partially reverts https://github.com/konflux-ci/dockerfile-json/commit/268e6b813d639cf5cd553ebb40554484d82313d8.

Note that proper usage of the API now requires the `InjectEnv()` method to be called before `Expand()` (if one wants to inject env variables), but that feels like an acceptable tradeoff. It brings the `Expand()` API back in line with the master branch and makes it unnecessary to pass both an argExpander and envExpander to `Expand()`