### PR TITLE
Don't require -tags=dfrunsecurity

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,29 @@ go get -u github.com/keilerkonzept/dockerfile-json
 
 Or [download the binary for your platform](https://github.com/keilerkonzept/dockerfile-json/releases/latest) from the releases page.
 
+### Build tags
+
+The `dfrunsecurity` build tag is optional but recommended when building from source.
+
+With the build tag:
+
+```bash
+go build -tags dfrunsecurity
+```
+
+- Supports parsing files with `RUN --security=insecure` and `RUN --security=sandbox` flags
+- The `Security` field in the JSON output will contain the parsed value (defaults to `sandbox`)
+
+Without the build tag:
+
+```bash
+go build
+```
+
+- Cannot parse files containing `RUN --security=*` flags (will return an error)
+- The `Security` field in JSON output will always be an empty string
+- Sufficient for use with e.g. Podman or Buildah, which do not support the `--security` flag
+
 ## Usage
 
 ### CLI
@@ -356,7 +379,7 @@ $ dockerfile-json --expand-build-args=false --jsonpath=..BaseName Dockerfile
 ### Running tests
 
 ```bash
-go test -tags=dfrunsecurity -v ./...
+go test -v ./...
 ```
 
 ### Adding integration tests
@@ -382,10 +405,10 @@ Generate expected outputs:
 
 ```bash
 # Generate for all test cases
-UPDATE_TESTDATA=1 go test -tags=dfrunsecurity
+UPDATE_TESTDATA=1 go test
 
 # Or generate for specific test case
-UPDATE_TESTDATA=1 go test -tags=dfrunsecurity -run=TestIntegration/my-scenario/variant-1
+UPDATE_TESTDATA=1 go test -run=TestIntegration/my-scenario/variant-1
 ```
 
 In this mode (`UPDATE_TESTDATA=1`), tests overwrite the `expected.json` files instead
@@ -398,6 +421,6 @@ The update mode is also useful when making changes to existing behavior. Re-gene
 the output files and verify that your changes achieved what you intended:
 
 ```bash
-UPDATE_TESTDATA=1 go test -tags=dfrunsecurity
+UPDATE_TESTDATA=1 go test
 git diff testdata/  # Review changes
 ```

--- a/integration_test.go
+++ b/integration_test.go
@@ -15,7 +15,7 @@ import (
 
 // TestIntegration discovers and runs all integration test cases in testdata/
 func TestIntegration(t *testing.T) {
-	binaryPath := buildBinary(t)
+	binaryPath := buildBinary(t, "-tags=dfrunsecurity")
 	defer os.Remove(binaryPath)
 
 	testCases := discoverTestCases(t)
@@ -30,6 +30,60 @@ func TestIntegration(t *testing.T) {
 	}
 }
 
+// TestWithoutRunsecurity verifies that compilation without -tags=dfrunsecurity is possible.
+func TestWithoutRunsecurity(t *testing.T) {
+	// Compiling without -tags=dfrunsecurity should succeed
+	binaryPath := buildBinary(t)
+
+	t.Run("SuccessfulParse", func(t *testing.T) {
+		containerfilePath := writeContainerfile(t, `
+FROM alpine
+
+RUN echo hi
+		`)
+
+		// Parsing a Containerfile without a 'RUN --security' instruction should succeed.
+		// The Security field in the JSON output should be empty.
+		cmd := exec.Command(binaryPath, "-jsonpath", ".Stages[0].Commands[0].Security", containerfilePath)
+
+		outBytes, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		output := strings.TrimSpace(string(outBytes))
+		if output != `""` {
+			t.Fatalf(`Expected Security attribute to be "", got %s`, output)
+		}
+	})
+
+	t.Run("FailedParse", func(t *testing.T) {
+		containerfilePath := writeContainerfile(t, `
+FROM alpine
+
+RUN --security=sandbox echo hi
+		`)
+
+		// Parsing a Containerfile with a 'RUN --security' instruction should fail
+		cmd := exec.Command(binaryPath, containerfilePath)
+		outBytes, err := cmd.CombinedOutput()
+
+		expectedError := "dockerfile parse error on line 4: unknown flag: --security"
+
+		switch err.(type) {
+		case *exec.ExitError:
+			output := strings.TrimSpace(string(outBytes))
+			if !strings.Contains(output, expectedError) {
+				t.Fatalf("unexpected error: %s", output)
+			}
+		case nil:
+			t.Fatal("expected command to fail, but it succeeded")
+		default:
+			t.Fatalf("expected command to result in ExitError, got %#v", err)
+		}
+	})
+}
+
 // testCase represents a single integration test case
 type testCase struct {
 	name         string
@@ -40,11 +94,15 @@ type testCase struct {
 }
 
 // buildBinary builds the dockerfile-json binary and returns its path
-func buildBinary(t *testing.T) string {
+func buildBinary(t *testing.T, buildFlags ...string) string {
 	t.Helper()
 
 	binaryPath := filepath.Join(t.TempDir(), "dockerfile-json")
-	cmd := exec.Command("go", "build", "-tags=dfrunsecurity", "-o", binaryPath, ".")
+	go_build_args := []string{"build", "-o", binaryPath}
+	go_build_args = append(go_build_args, buildFlags...)
+
+	cmd := exec.Command("go", go_build_args...)
+
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("Failed to build binary: %v\nOutput: %s", err, output)
@@ -206,4 +264,17 @@ func compareJSON(t *testing.T, expected, actual []byte) error {
 	}
 
 	return nil
+}
+
+// Writes the specified content into <t.TempDir()>/Containerfile and returns the Containerfile path.
+func writeContainerfile(t *testing.T, content string) string {
+	tmpdir := t.TempDir()
+	path := filepath.Join(tmpdir, "Containerfile")
+
+	err := os.WriteFile(path, []byte(content), 0644)
+	if err != nil {
+		t.Fatalf("failed to write %s: %s", path, err)
+	}
+
+	return path
 }

--- a/pkg/dockerfile/parse.go
+++ b/pkg/dockerfile/parse.go
@@ -53,7 +53,7 @@ func ParseReader(r io.Reader) (*Dockerfile, error) {
 			case *instructions.RunCommand:
 				outCommand.Mounts = instructions.GetMounts(command)
 				outCommand.NetworkMode = instructions.GetNetwork(command)
-				outCommand.Security = instructions.GetSecurity(command)
+				outCommand.Security = getSecurity(command)
 			}
 			outStage.Commands = append(outStage.Commands, outCommand)
 		}

--- a/pkg/dockerfile/runsecurity.go
+++ b/pkg/dockerfile/runsecurity.go
@@ -1,0 +1,12 @@
+//go:build dfrunsecurity
+
+package dockerfile
+
+import "github.com/moby/buildkit/frontend/dockerfile/instructions"
+
+// Buildkit exports the GetSecurity function only when using -tags=dfrunsecurity.
+// To avoid compilation errors, use a wrapper whose implementation calls GetSecurity
+// only when using -tags=dfrunsecurity. See also ./runsecurity_stub.go
+func getSecurity(cmd *instructions.RunCommand) string {
+	return instructions.GetSecurity(cmd)
+}

--- a/pkg/dockerfile/runsecurity_stub.go
+++ b/pkg/dockerfile/runsecurity_stub.go
@@ -1,0 +1,13 @@
+//go:build !dfrunsecurity
+
+package dockerfile
+
+import "github.com/moby/buildkit/frontend/dockerfile/instructions"
+
+// Buildkit exports the GetSecurity function only when using -tags=dfrunsecurity.
+// When not using the tag, do not attempt to call the function and just return an
+// empty string. A Dockerfile that includes a 'RUN --security' instruction will
+// cause a parse error anyway. See also ./runsecurity.go
+func getSecurity(cmd *instructions.RunCommand) string {
+	return ""
+}


### PR DESCRIPTION
Requiring this specific tag makes for a bad developer experience, since one always has to provide it when running 'go build', 'go test' etc. And failing to compile due to an undefined function name is a bad look.

It is especially bad when using this package as a library, since it forces -tags=dfrunsecurity during compilation of the dependent project.

Make this tag optional. When not provided, the resulting binary will not be able to parse Containerfiles with 'RUN --security=*' instructions. For the use case of parsing Containerfiles used with buildah/podman, this doesn't matter, since those tools don't support --security either.