### PR TITLE
Fix analyzeStages not clearing stale From fields after Expand

### DIFF
--- a/pkg/dockerfile/analyze.go
+++ b/pkg/dockerfile/analyze.go
@@ -4,6 +4,7 @@ func (d *Dockerfile) analyzeStages() {
 	seenStageNames := make(map[string]int)
 	for i, stage := range d.Stages {
 		stageIndex, stageIndexOK := seenStageNames[stage.BaseName]
+		stage.From = From{}
 		switch {
 		case stageIndexOK:
 			stage.From.Stage = &FromStage{
@@ -12,7 +13,6 @@ func (d *Dockerfile) analyzeStages() {
 			}
 		case stage.BaseName == "scratch":
 			stage.From.Scratch = true
-			stage.From.Image = nil
 		default:
 			stage.From.Image = &stage.BaseName
 		}

--- a/testdata/stage-name-interpolation/Containerfile
+++ b/testdata/stage-name-interpolation/Containerfile
@@ -1,0 +1,4 @@
+ARG TARGETARCH=amd64
+FROM --platform=linux/amd64 alpine AS base-amd64
+FROM --platform=linux/arm64 alpine AS base-arm64
+FROM base-${TARGETARCH} AS base

--- a/testdata/stage-name-interpolation/expected.json
+++ b/testdata/stage-name-interpolation/expected.json
@@ -1,0 +1,90 @@
+{
+  "MetaArgs": [
+    {
+      "Key": "TARGETARCH",
+      "DefaultValue": "amd64",
+      "ProvidedValue": "amd64",
+      "Value": "amd64"
+    }
+  ],
+  "Stages": [
+    {
+      "Name": "base-amd64",
+      "OrigCmd": "FROM",
+      "BaseName": "alpine",
+      "Platform": "linux/amd64",
+      "Comment": "",
+      "SourceCode": "FROM --platform=linux/amd64 alpine AS base-amd64",
+      "Location": [
+        {
+          "Start": {
+            "Line": 2,
+            "Character": 0
+          },
+          "End": {
+            "Line": 2,
+            "Character": 0
+          }
+        }
+      ],
+      "As": "base-amd64",
+      "From": {
+        "Image": "alpine"
+      },
+      "Commands": null
+    },
+    {
+      "Name": "base-arm64",
+      "OrigCmd": "FROM",
+      "BaseName": "alpine",
+      "Platform": "linux/arm64",
+      "Comment": "",
+      "SourceCode": "FROM --platform=linux/arm64 alpine AS base-arm64",
+      "Location": [
+        {
+          "Start": {
+            "Line": 3,
+            "Character": 0
+          },
+          "End": {
+            "Line": 3,
+            "Character": 0
+          }
+        }
+      ],
+      "As": "base-arm64",
+      "From": {
+        "Image": "alpine"
+      },
+      "Commands": null
+    },
+    {
+      "Name": "base",
+      "OrigCmd": "FROM",
+      "BaseName": "base-amd64",
+      "Platform": "",
+      "Comment": "",
+      "SourceCode": "FROM base-${TARGETARCH} AS base",
+      "Location": [
+        {
+          "Start": {
+            "Line": 4,
+            "Character": 0
+          },
+          "End": {
+            "Line": 4,
+            "Character": 0
+          }
+        }
+      ],
+      "As": "base",
+      "From": {
+        "Stage": {
+          "Named": "base-amd64",
+          "Index": 0
+        }
+      },
+      "Commands": null
+    }
+  ]
+}


### PR DESCRIPTION
When analyzeStages() runs after Expand(), a FROM reference like base-${TARGETARCH} that initially resolved to an image (From.Image) would get From.Stage correctly set once expansion resolved it to a known stage name, but the stale From.Image was never cleared.

Reset From to its zero value at the start of each iteration so only the correct field is set regardless of prior state.