### PR TITLE
Expand variable references in Platform field of FROM directives

### DIFF
--- a/pkg/dockerfile/expand.go
+++ b/pkg/dockerfile/expand.go
@@ -68,6 +68,9 @@ func (d *Dockerfile) expand(argExp instructions.SingleWordExpander) {
 		if expanded, _, err := lex.ProcessWord(d.Stages[i].BaseName, metaEnv); err == nil {
 			d.Stages[i].BaseName = expanded
 		}
+		if expanded, _, err := lex.ProcessWord(d.Stages[i].Platform, metaEnv); err == nil {
+			d.Stages[i].Platform = expanded
+		}
 
 		localArgs := make(map[string]string)
 		localEnvs := make(map[string]string)

--- a/testdata/platform-variable-expansion/Containerfile
+++ b/testdata/platform-variable-expansion/Containerfile
@@ -1,0 +1,2 @@
+ARG PLATFORM=linux/amd64
+FROM --platform=${PLATFORM} alpine

--- a/testdata/platform-variable-expansion/expected.json
+++ b/testdata/platform-variable-expansion/expected.json
@@ -1,0 +1,36 @@
+{
+  "MetaArgs": [
+    {
+      "Key": "PLATFORM",
+      "DefaultValue": "linux/amd64",
+      "ProvidedValue": null,
+      "Value": "linux/amd64"
+    }
+  ],
+  "Stages": [
+    {
+      "Name": "",
+      "OrigCmd": "FROM",
+      "BaseName": "alpine",
+      "Platform": "linux/amd64",
+      "Comment": "",
+      "SourceCode": "FROM --platform=${PLATFORM} alpine",
+      "Location": [
+        {
+          "Start": {
+            "Line": 2,
+            "Character": 0
+          },
+          "End": {
+            "Line": 2,
+            "Character": 0
+          }
+        }
+      ],
+      "From": {
+        "Image": "alpine"
+      },
+      "Commands": null
+    }
+  ]
+}


### PR DESCRIPTION
The Platform field (FROM --platform=...) was not being expanded, leaving variable references like ${PLATFORM} unresolved in the JSON output. Apply the same ProcessWord expansion used for BaseName.